### PR TITLE
1) Fixed bugs in a few places where ghost wait list counts were being…

### DIFF
--- a/classes/class-woo-product-stock-alert-action.php
+++ b/classes/class-woo-product-stock-alert-action.php
@@ -59,6 +59,8 @@ class WOO_Product_Stock_Alert_Action {
                         update_post_meta($all_product_id, 'no_of_subscribers', $interest_persons);
                     }
                 } else {
+                    doWooStockAlertLOG('deleting post_meta for product_id '
+                        . $all_product_id . ' :: _product_subscriber=' . implode(";",get_post_meta($all_product_id, '_product_subscriber', true)));
                     delete_post_meta($all_product_id, '_product_subscriber');
                     delete_post_meta($all_product_id, 'no_of_subscribers');
                 }
@@ -83,8 +85,10 @@ class WOO_Product_Stock_Alert_Action {
                                 foreach ($subscriber as $to) {
                                     $email->trigger($to, $id);
                                 }
-
+                                doWooStockAlertLOG('deleting post_meta for product_id '
+                                    . $id . ' :: _product_subscriber=' . implode(";",get_post_meta($id, '_product_subscriber', true)));
                                 delete_post_meta($id, '_product_subscriber');
+                                delete_post_meta($id, 'no_of_subscribers');
                             }
                         } else {
                             $email = WC()->mailer()->emails['WC_Email_Stock_Alert'];
@@ -92,7 +96,10 @@ class WOO_Product_Stock_Alert_Action {
                                 $email->trigger($to, $id);
                             }
 
+                            doWooStockAlertLOG('deleting post_meta for product_id '
+                                . $id . ' :: _product_subscriber=' . implode(";",get_post_meta($id, '_product_subscriber', true)));
                             delete_post_meta($id, '_product_subscriber');
+                            delete_post_meta($id, 'no_of_subscribers');
                         }
                     } elseif (!$managing_stock && $product_availability_stock > 0) {
                         if ($product->backorders_allowed() && isset($dc_settings['is_enable_backorders']) && $dc_settings['is_enable_backorders'] == 'Enable') {
@@ -102,7 +109,10 @@ class WOO_Product_Stock_Alert_Action {
                                     $email->trigger($to, $id);
                                 }
 
+                                doWooStockAlertLOG('deleting post_meta for product_id '
+                                    . $id . ' :: _product_subscriber=' . implode(";",get_post_meta($id, '_product_subscriber', true)));
                                 delete_post_meta($id, '_product_subscriber');
+                                delete_post_meta($id, 'no_of_subscribers');
                             }
                         } else {
                             $email = WC()->mailer()->emails['WC_Email_Stock_Alert'];
@@ -110,7 +120,10 @@ class WOO_Product_Stock_Alert_Action {
                                 $email->trigger($to, $id);
                             }
 
+                            doWooStockAlertLOG('deleting post_meta for product_id '
+                                . $id . ' :: _product_subscriber=' . implode(";",get_post_meta($id, '_product_subscriber', true)));
                             delete_post_meta($id, '_product_subscriber');
+                            delete_post_meta($id, 'no_of_subscribers');
                         }
                     }
                 }

--- a/classes/class-woo-product-stock-alert-admin.php
+++ b/classes/class-woo-product-stock-alert-admin.php
@@ -75,6 +75,8 @@ class WOO_Product_Stock_Alert_Admin {
         foreach ($post_ids as $post_id) {
             $product = wc_get_product($post_id);
             if($product && $product->get_parent_id() != 0 && get_post_meta( $post_id, '_product_subscriber', true )){
+                doWooStockAlertLOG('deleting post_meta for product_id '
+                    . $post_id. ' :: _product_subscriber=' . implode(";",get_post_meta($post_id, '_product_subscriber', true)));
                 delete_post_meta( $product->get_parent_id(), 'no_of_subscribers' );
                 delete_post_meta( $post_id, '_product_subscriber' );
             } if($product && $product->is_type('variable')) {
@@ -82,12 +84,16 @@ class WOO_Product_Stock_Alert_Admin {
                         $child_ids = $product->get_children();
                         if (isset($child_ids) && !empty($child_ids)) {
                             foreach ($child_ids as $child_id) {
+                                doWooStockAlertLOG('deleting post_meta for product_id '
+                                    . $child_id. ' :: _product_subscriber=' . implode(";",get_post_meta($child_id, '_product_subscriber', true)));
                                 delete_post_meta( $child_id, 'no_of_subscribers' );
                                 delete_post_meta( $child_id, '_product_subscriber' );
                             }
                         }
                     }
 			} else {
+                doWooStockAlertLOG('deleting post_meta for product_id '
+                    . $post_id . ' :: _product_subscriber=' . implode(";",get_post_meta($post_id, '_product_subscriber', true)));
                 delete_post_meta( $post_id, 'no_of_subscribers' );
                 delete_post_meta( $post_id, '_product_subscriber' );
             }
@@ -404,6 +410,8 @@ class WOO_Product_Stock_Alert_Admin {
                                         foreach ($product_subscriber as $to) {
                                             $email->trigger($to, $child_id);
                                         }
+                                        doWooStockAlertLOG('deleting post_meta for product_id '
+                                            . $child_id. ' :: _product_subscriber=' . implode(";",get_post_meta($child_id, '_product_subscriber', true)));
                                         delete_post_meta($child_id, '_product_subscriber');
                                         $parent_product_subscribers = get_post_meta($child_obj->get_parent_id(), 'no_of_subscribers', true);
                                         update_post_meta($child_obj->get_parent_id(), 'no_of_subscribers', $parent_product_subscribers - count($product_subscriber));
@@ -425,7 +433,10 @@ class WOO_Product_Stock_Alert_Admin {
                             foreach ($product_subscriber as $to) {
                                 $email->trigger($to, $post_id);
                             }
+                            doWooStockAlertLOG('deleting post_meta for product_id '
+                                . $post_id. ' :: _product_subscriber=' . implode(";", get_post_meta($post_id, '_product_subscriber', true)));
                             delete_post_meta($post_id, '_product_subscriber');
+                            delete_post_meta($post_id, 'no_of_subscribers');
                         }
                     }
                 }

--- a/classes/class-woo-product-stock-alert-ajax.php
+++ b/classes/class-woo-product-stock-alert-ajax.php
@@ -135,6 +135,8 @@ class WOO_Product_Stock_Alert_Ajax {
 				update_post_meta($product_id, 'no_of_subscribers', $interest_persons);
 			}
 		} else {
+            doWooStockAlertLOG('12 deleting post_meta for product_id '
+                . $product_id. ' :: _product_subscriber=' . get_post_meta($product_id, '_product_subscriber', true));
 			delete_post_meta( $product_id, '_product_subscriber' );
 			delete_post_meta( $product_id, 'no_of_subscribers' );
 		}

--- a/classes/emails/class-woo-product-stock-alert-admin-email.php
+++ b/classes/emails/class-woo-product-stock-alert-admin-email.php
@@ -57,7 +57,7 @@ class WC_Admin_Email_Stock_Alert extends WC_Email {
 		if ( ! $this->is_enabled() || ! $this->get_recipient() ) {
 			return;
 		}
-		
+        doWooStockAlertLOG('emailing from ' . $recipient . ' to customer_email ' . $customer_email . ' RE: Product ID=' . $product_id);
 		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 	}
 

--- a/includes/woo-product-stock-alert-core-functions.php
+++ b/includes/woo-product-stock-alert-core-functions.php
@@ -162,26 +162,17 @@ if (!function_exists('display_stock_alert_form')) {
  */
 if (!function_exists('doWooStockAlertLOG')) {
 
-    function doWooStockAlertLOG($str) {
-        $file = plugin_dir_path(__FILE__) . 'stock_alert_log.log';
-        if (file_exists($file)) {
-            $temphandle = @fopen($file, 'w+'); // @codingStandardsIgnoreLine.
-            @fclose($temphandle); // @codingStandardsIgnoreLine.
-            if (defined('FS_CHMOD_FILE')) {
-                @chmod($file, FS_CHMOD_FILE); // @codingStandardsIgnoreLine.
-            }
-            // Open the file to get existing content
-            $current = file_get_contents($file);
-            // Append a new content to the file
-            $current .= "$str" . "\r\n";
-            $current .= "-------------------------------------\r\n";
-        } else {
-            $current = "$str" . "\r\n";
-            $current .= "-------------------------------------\r\n";
+    function doWooStockAlertLOG($str, $put_in_daily_log = true) {
+        $date = new DateTime();
+        $file = plugin_dir_path(__DIR__) . 'logs/stock_alert_log.log';
+        if ($put_in_daily_log) {
+            $file = plugin_dir_path(__DIR__) . 'logs/stock_alert_log-' . $date->format("Y-m-d") . '.log';
         }
-        // Write the contents back to the file
-        file_put_contents($file, $current);
-    }
+        $strToWrite = $date->format("Y-m-d H:i:s T") . " : " . $str . "\r\n";
 
+        // Append or create log file and save the content
+        file_put_contents($file, $strToWrite, (file_exists($file) ? FILE_APPEND : null));
+
+    }
 }
 ?>


### PR DESCRIPTION
… kept in the no_of_subscribers custom field... the no_of_subscribers was not deleted or zeroed after you restock. Emails went out, but this count wasnt updated correctly to zero. It will correct itself once you run out of stock again and the first person adds themself to the new list.  Query to look for these ghost values -- select * from machete.machetestore_postmeta mp where meta_key = "no_of_subscribers" and post_id not in (select post_id from machete.machetestore_postmeta mp where meta_key = "_product_subscriber") order by post_id;

2) Added functional logging everywhere an email is sent or data is deleted from the database
3) Moved logging to /logs folder.  Creates a new file for each day's log activities. Optionally can change that to just log to a single file