### PR TITLE
Plugin additions

### DIFF
--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -80,7 +80,7 @@ jQuery(document).ready(function($) {
 			
 			alert_email_exist = alert_email_exist.replace( '%product_title%', pro_title );
 			alert_email_exist = alert_email_exist.replace( '%customer_email%', cus_email );
-			
+
 			if( cus_email && validateEmail(cus_email) ) {
 				$(this).toggleClass('alert_loader').blur();	
 				var stock_alert = {
@@ -88,6 +88,11 @@ jQuery(document).ready(function($) {
 					email: cus_email,
 					product_id: pro_id
 				}
+
+				for (var i=0; i<woo_stock_alert_script_data.additional_fields.length; i++){
+					stock_alert[woo_stock_alert_script_data.additional_fields[i]] = $(this).parent().find('.'+woo_stock_alert_script_data.additional_fields[i]).val();
+				}
+
 				$.post(woo_stock_alert_script_data.ajax_url, stock_alert, function(response) { console.log(response);
 					$this.removeClass('alert_loader').blur();	
 					if( response == '0' ) {
@@ -124,7 +129,7 @@ jQuery(document).ready(function($) {
 			
 			alert_email_exist = alert_email_exist.replace( '%product_title%', pro_title );
 			alert_email_exist = alert_email_exist.replace( '%customer_email%', cus_email );
-			
+
 			if( cus_email && validateEmail(cus_email) ) {
 				$(this).attr("value",woo_stock_alert_script_data.processing);
 				$(this).addClass("stk_disabled");	
@@ -133,6 +138,12 @@ jQuery(document).ready(function($) {
 					email: cus_email,
 					product_id: variation_id
 				}
+
+
+				for (var i=0; i<woo_stock_alert_script_data.additional_fields.length; i++){
+					stock_alert[woo_stock_alert_script_data.additional_fields[i]] = $(this).parent().find('.'+woo_stock_alert_script_data.additional_fields[i]).val();
+				}
+
 				$.post(woo_stock_alert_script_data.ajax_url, stock_alert, function(response) {
 					$(this).removeClass("stk_disabled");	
 					if( response == '0' ) {

--- a/classes/class-woo-product-stock-alert-ajax.php
+++ b/classes/class-woo-product-stock-alert-ajax.php
@@ -185,7 +185,8 @@ class WOO_Product_Stock_Alert_Ajax {
 
 				$cust_mail->trigger( $customer_email, $product_id );
 			}
-		} else {
+            do_action( 'woocommerce_product_stock_alert_form_process_additional_fields', $customer_email, $product_id );
+        } else {
 			if( !in_array( $customer_email, $current_subscriber ) ) {
 				if ( $do_complete_additional_task ) {
 					do_action( 'dc_wc_product_stock_alert_new_subscriber_added', $customer_email, $product_id );
@@ -198,7 +199,8 @@ class WOO_Product_Stock_Alert_Ajax {
 				
 					$cust_mail->trigger( $customer_email, $product_id );
 				}
-			} else {
+                do_action( 'woocommerce_product_stock_alert_form_process_additional_fields', $customer_email, $product_id );
+            } else {
 				$status = '/*?%already_registered%?*/';
 			}
 		}

--- a/classes/class-woo-product-stock-alert-frontend.php
+++ b/classes/class-woo-product-stock-alert-frontend.php
@@ -94,6 +94,7 @@ class WOO_Product_Stock_Alert_Frontend {
                 wp_enqueue_script('stock_alert_frontend_js', $frontend_script_path . 'frontend.js', array('jquery'), $WOO_Product_Stock_Alert->version, true);
             
                 wp_localize_script('stock_alert_frontend_js', 'woo_stock_alert_script_data', array('ajax_url' => admin_url('admin-ajax.php', 'relative'),
+                    'additional_fields' => apply_filters('woocommerce_product_stock_alert_form_additional_fields', []),
                     'alert_text_html' => $alert_text_html,
                     'button_html' => $button_html,
                     'alert_success' => $alert_success,
@@ -234,14 +235,24 @@ class WOO_Product_Stock_Alert_Frontend {
         }
         $placeholder = __('Enter your email', 'woocommerce-product-stock-alert');
         $placeholder = apply_filters('wc_product_stock_alert_box_email_placeholder', $placeholder);
-        $stock_interest .= '<div class="alert_container">
+
+        $stock_interest .= apply_filters('woocommerce_product_stock_alert_form', '<div class="alert_container">
 								' . $alert_text_html . '
 								<input type="text" class="stock_alert_email" name="alert_email" value="' . $user_email . '" placeholder="' . $placeholder . '" />
 								' . $button_html . '
 								<input type="hidden" class="current_product_id" value="' . $product->get_id() . '" />
 								<input type="hidden" class="current_product_name" value="' . $product->get_title() . '" />
 								' . $shown_interest_section . '
-							</div>';
+							</div>', $alert_text_html, $user_email, $button_html, $product, $shown_interest_section);
+
+        /*$stock_interest .= '<div class="alert_container">
+								' . $alert_text_html . '
+								<input type="text" class="stock_alert_email" name="alert_email" value="' . $user_email . '" placeholder="' . $placeholder . '" />
+								' . $button_html . '
+								<input type="hidden" class="current_product_id" value="' . $product->get_id() . '" />
+								<input type="hidden" class="current_product_name" value="' . $product->get_title() . '" />
+								' . $shown_interest_section . '
+							</div>';*/
 
         if ($product->is_type('simple')) {
             if ($this->display_stock_alert_form($product)) {

--- a/classes/shortcode/class-woo-product-stock-alert-shortcode-display-stock-alert-form.php
+++ b/classes/shortcode/class-woo-product-stock-alert-shortcode-display-stock-alert-form.php
@@ -94,6 +94,7 @@ class WOO_Product_Stock_Alert_Display_Form {
         }
         
         wp_localize_script('stock_alert_frontend_js', 'woo_stock_alert_script_data', array('ajax_url' => admin_url('admin-ajax.php', 'relative'),
+            'additional_fields' => apply_filters('woocommerce_product_stock_alert_form_additional_fields', []),
             'alert_text_html' => $alert_text_html,
             'button_html' => $button_html,
             'alert_success' => $alert_success,
@@ -109,24 +110,19 @@ class WOO_Product_Stock_Alert_Display_Form {
         if (is_user_logged_in()) {
             $current_user = wp_get_current_user();
             $user_email = $current_user->data->user_email;
-            $stock_interest = '<div class="alert_container">
-									' . $alert_text_html . '
-									<input type="text" class="stock_alert_email" name="alert_email" value="' . $user_email . '" />
-									' . $button_html . '
-									<input type="hidden" class="current_product_id" value="' . $product->get_id() . '" />
-									<input type="hidden" class="current_product_name" value="' . $product->get_title() . '" />
-									' . $shown_interest_section . '
-								</div>';
+
         } else {
-            $stock_interest = '<div class="alert_container">
+            $user_email = '';
+        }
+
+        $stock_interest = apply_filters('woocommerce_product_stock_alert_form', '<div class="alert_container">
 									' . $alert_text_html . '
-									<input type="text" class="stock_alert_email" name="alert_email" placeholder="abc@example.com" />
+									<input type="text" class="stock_alert_email" name="alert_email" placeholder="abc@example.com" value="' . $user_email . '" />
 									' . $button_html . '
 									<input type="hidden" class="current_product_id" value="' . $product->get_id() . '" />
 									<input type="hidden" class="current_product_name" value="' . $product->get_title() . '" />
 									' . $shown_interest_section . '
-								</div>';
-        }
+								</div>', $alert_text_html, $user_email, $button_html, $product, $shown_interest_section);
 
         if ($product->is_type('simple')) {
             if (display_stock_alert_form($product)) {


### PR DESCRIPTION
Hello,
I added:

- woocommerce_product_stock_alert_form filter in order to customize alert form
- woocommerce_product_stock_alert_form_additional_fields in order to add additional fields sent in alert form
- woocommerce_product_stock_alert_form_process_additional_fields filter in order to process additional fields sent in the alert form

The purpose is customize the alert form:
- first filter allows to change form HTML (user could define additional form input providing custom HTML classes)
- with the second filter it's possible to specify list of additional fields (User will use input classes defined in form HTML)
- last action allows to create an additional (it will be possible to access additional fields using $_POST)

Let me know if you appreciate these changes and if you want to apply improvements, in case I can also create WP documentation.

