### PR TITLE
Uncaught TypeError : Fixed #41

### DIFF
--- a/classes/class-woo-product-stock-alert-ajax.php
+++ b/classes/class-woo-product-stock-alert-ajax.php
@@ -216,6 +216,14 @@ class WOO_Product_Stock_Alert_Ajax {
                             foreach ($child_ids as $child_id) {
                             	$no_of_subscribers = 0;
                             	$no_of_subscribers = get_post_meta( $child_id, 'no_of_subscribers', true );
+				    
+				    	//Modified code for not getting uncaught error  types string + int
+
+                            	if ($no_of_subscribers  > 0) {                                                  
+                            		$no_of_subscribers = intval($no_of_subscribers);
+                            		
+                            	}
+				    
                             	if($product_id == $child_id) $no_of_subscribers++;
                             	$no_of_total_subscribers += $no_of_subscribers;
                             	if($no_of_subscribers > 0) update_post_meta($child_id, 'no_of_subscribers', $no_of_subscribers);


### PR DESCRIPTION
E_ERROR (1): Uncaught TypeError: Unsupported operand types: int + string in /wp-content/plugins/woocommerce-product-stock-alert/classes/class-woo-product-stock-alert-ajax.php:220 
This issue fixed.

To avoid this error please cast the variable you get the number of subscribers via get_post_meta as integer. Sometime the DB only returns an empty string instead of an integer.

To avoid this error please cast the variable you get the number of subscribers via get_post_meta as integer. Sometime the DB only returns an empty string instead of an integer.
To avoid this error we cast the variable that get the number of subscribers via get-post-meta as integer. Sometime the DB only returns an empty string instead of an integer.
So adding
$no_of_subscribers = intval($no_of_subscribers);